### PR TITLE
Fix microscheme link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A firmware for the
 [Atreus](http://atreus.technomancy.us) keyboard, written in
-[Microscheme](http://microscheme.org).
+[Microscheme](http://www.suchocki.co.uk/microscheme/).
 
 Written in an incremental style. Requires microscheme newer than 0.8; at
 the time of this writing only available on git master.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A firmware for the
 [Atreus](http://atreus.technomancy.us) keyboard, written in
-[Microscheme](http://www.suchocki.co.uk/microscheme/).
+[Microscheme](http://ryansuchocki.github.io/microscheme/).
 
 Written in an incremental style. Requires microscheme newer than 0.8; at
 the time of this writing only available on git master.


### PR DESCRIPTION
microscheme.org now redirect to a super scammy looking set of sites. Looks like microscheme is now hosted [here](http://www.suchocki.co.uk/microscheme/) This updates the link in the README